### PR TITLE
Enable dynamic model selection for deployment comparison

### DIFF
--- a/src/main/java/com/epam/training/gen/ai/chat/controller/ChatBotController.java
+++ b/src/main/java/com/epam/training/gen/ai/chat/controller/ChatBotController.java
@@ -2,12 +2,12 @@ package com.epam.training.gen.ai.chat.controller;
 
 import com.epam.training.gen.ai.chat.model.PromptResponse;
 import com.epam.training.gen.ai.chat.service.PromptService;
+import com.epam.training.gen.ai.chat.util.DeploymentModel;
 import com.epam.training.gen.ai.chat.util.ValidationUtils;
 import com.epam.training.gen.ai.configuration.PromptExecutionConfig;
 import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Primary;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -32,12 +32,13 @@ public class ChatBotController {
     }
 
     @GetMapping("prompt")
-    public Map<String, Object> prompt(@RequestParam(required = false) String userPrompt, @RequestParam(required = false) double temperature) {
+    public Map<String, Object> prompt(@RequestParam(required = false) String userPrompt, @RequestParam(required = false) double temperature, @RequestParam("model")  DeploymentModel deploymentModel) {
         ValidationUtils.validateUserPrompt(userPrompt);
         ValidationUtils.validateTemperature(temperature);
+        ValidationUtils.validateDeploymentModel(deploymentModel);
         promptExecutionConfig = PromptExecutionConfig.builder().temperature(temperature)
                 .maxTokensPerPrompt(promptExecutionConfig.getMaxTokensPerPrompt())
-                .deploymentName( promptExecutionConfig.getDeploymentName())
+                .deploymentName(deploymentModel.getModelName())
                 .build();
 
         log.debug("Prompt execution config: tokens - {},deployment- {}, temperature {} ",promptExecutionConfig.getMaxTokensPerPrompt(), promptExecutionConfig.getDeploymentName(), promptExecutionConfig.getTemperature());

--- a/src/main/java/com/epam/training/gen/ai/chat/util/DeploymentModel.java
+++ b/src/main/java/com/epam/training/gen/ai/chat/util/DeploymentModel.java
@@ -1,0 +1,4 @@
+package com.epam.training.gen.ai.chat.util;
+
+public class DeploymentModel {
+}

--- a/src/main/java/com/epam/training/gen/ai/chat/util/DeploymentModel.java
+++ b/src/main/java/com/epam/training/gen/ai/chat/util/DeploymentModel.java
@@ -1,4 +1,24 @@
 package com.epam.training.gen.ai.chat.util;
 
-public class DeploymentModel {
+import java.util.Arrays;
+import java.util.stream.DoubleStream;
+import java.util.stream.Stream;
+
+public enum DeploymentModel {
+    GPT_3_5_TURBO("gpt-35-turbo-1106"),
+    GPT_4("gpt-4"),
+    GOOGLE_CHAT_BISON("chat-bison@001");
+    private final String modelName;
+    DeploymentModel(String modelName) {
+        this.modelName = modelName;
+    }
+
+    public static Stream<DeploymentModel> valuesAsStream() {
+        return Arrays.stream(DeploymentModel.values());
+    }
+
+    public String getModelName() {
+        return modelName;
+    }
 }
+

--- a/src/main/java/com/epam/training/gen/ai/chat/util/ValidationUtils.java
+++ b/src/main/java/com/epam/training/gen/ai/chat/util/ValidationUtils.java
@@ -15,4 +15,16 @@ public class ValidationUtils {
             throw new IllegalArgumentException(INVALID_TEMPERATURE_MESSAGE);
         }
     }
+
+    public static void validateDeploymentModel(DeploymentModel deploymentModel) {
+        if (deploymentModel == null || deploymentModel.getModelName() == null || deploymentModel.getModelName().trim().isEmpty()) {
+            throw new IllegalArgumentException("Deployment model name cannot be  null or empty");
+        }
+        if (DeploymentModel.valuesAsStream()
+                .noneMatch(model -> model.getModelName().equals(deploymentModel.getModelName()))) {
+            throw new IllegalArgumentException("Deployment model name is not valid");
+        }
+       
+        
+    }
 }


### PR DESCRIPTION
**Description:**

This pull request implements the ability to dynamically pass deployment models for testing and comparison. It includes support for evaluating GPT-3.5, GPT-4, and Google Chat Bison models. 

### Changes:
- Added functionality to dynamically select and test different deployment models.
- Integrated evaluation for GPT-3.5, GPT-4, and Google Chat Bison.

This enhancement allows easier experimentation and analysis of model performance across different deployments. 
